### PR TITLE
SYS-1820: Python API experiments

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,41 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/docker-existing-dockerfile
+{
+	"image": "xero-invoicing-xero:latest",
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"ms-python.python",
+				"ms-python.black-formatter",
+				"ms-python.flake8"
+			],
+			"settings": {
+				"editor.formatOnSave": true,
+				"python.analysis.typeCheckingMode": "standard",
+				"python.editor.defaultFormatter": "ms-python.black-formatter",
+		    	"flake8.args": [
+					"--max-line-length=100",
+					"--extend-ignore=E203"
+				]
+			}
+		}
+	},
+	"workspaceMount": "source=${localWorkspaceFolder},target=/home/xero/project,type=bind",
+	"workspaceFolder": "/home/xero/project"
+
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Uncomment the next line to run commands after the container is created.
+	// "postCreateCommand": "cat /etc/os-release",
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as an existing user other than the container default. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "devcontainer"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,7 @@ cython_debug/
 
 # PyPI configuration file
 .pypirc
+
+# Local secrets
+*secret*
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+FROM python:3.13-slim-bookworm
+
+# Set correct timezone
+RUN ln -sf /usr/share/zoneinfo/America/Los_Angeles /etc/localtime
+
+# Create generic xero user
+RUN useradd -c "generic app user" -d /home/xero -s /bin/bash -m xero
+
+# Switch to application directory, creating it if needed
+WORKDIR /home/xero/project
+
+# Make sure xero owns app directory, if WORKDIR created it:
+# https://github.com/docker/docs/issues/13574
+RUN chown -R xero:xero /home/xero
+
+# Change context to xero user for remaining steps
+USER xero
+
+# Copy application files to image, and ensure xero user owns everything
+COPY --chown=xero:xero . .
+
+# Include local python bin into xero user's path, mostly for pip
+ENV PATH=/home/xero/.local/bin:${PATH}
+
+# Make sure pip is up to date, and don't complain if it isn't yet
+RUN pip install --upgrade pip --disable-pip-version-check
+
+# Install requirements for this application
+RUN pip install --no-cache-dir -r requirements.txt --user --no-warn-script-location

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+services:
+  xero:
+    build: .
+    # tty: true
+    volumes: 
+      - .:/home/xero/project

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+# Official Xero API SDK
+xero-python==8.1.0
+# For OAuth
+# Authlib==1.6.0
+oauthlib==3.2.2
+requests==2.32.3

--- a/xero_api_test.py
+++ b/xero_api_test.py
@@ -1,0 +1,204 @@
+import argparse
+import requests
+import tomllib
+import webbrowser
+from oauthlib.oauth2 import WebApplicationClient
+from typing import TypeAlias
+from urllib.parse import parse_qsl, urlparse
+
+# from xero_python.accounting import AccountingApi
+# from xero_python.api_client import ApiClient
+# from xero_python.api_client.configuration import Configuration
+# from xero_python.api_client.oauth2 import OAuth2Token
+
+from pprint import pprint
+
+# For convenience
+config_dict: TypeAlias = dict[str, str]
+
+
+def _get_args() -> argparse.Namespace:
+    """Returns the command-line arguments for this program."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--config_file", help="Path to configuration file", required=True
+    )
+    args = parser.parse_args()
+    return args
+
+
+def _get_config(config_file_name: str) -> dict[str, config_dict]:
+    """Returns configuration for this program, loaded from TOML file."""
+    with open(config_file_name, "rb") as f:
+        config = tomllib.load(f)
+    return config
+
+
+def _get_xero_config(config_file_name: str) -> config_dict:
+    config = _get_config(config_file_name)
+    return config["xero"]
+
+
+def _get_auth_request_url(xero_config: config_dict) -> str:
+    oauth_client = WebApplicationClient(xero_config["client_id"])
+    auth_request_url = oauth_client.prepare_request_uri(
+        uri=xero_config["authorization_url"],
+        redirect_uri=xero_config["redirect_url"],
+        scope=[xero_config["scope"]],
+        state=xero_config["state"],
+    )
+    return auth_request_url
+
+
+def _get_auth_code(url: str) -> str:
+    url_query = urlparse(url).query
+    query_data = dict(parse_qsl(url_query))
+    return query_data["code"]
+
+
+def _get_refresh_token(xero_config: config_dict) -> str | None:
+    try:
+        with open(xero_config["refresh_token_file"], "r") as f:
+            refresh_token = f.read()
+    except FileNotFoundError:
+        refresh_token = None
+    return refresh_token
+
+
+def _store_refresh_token(xero_config: config_dict, refresh_token: str) -> None:
+    with open(xero_config["refresh_token_file"], "w") as f:
+        f.write(refresh_token)
+
+
+def _get_token_from_auth_code(auth_code: str, xero_config: config_dict) -> str:
+    # requests basic auth: auth=(client_id, client_secret)
+    # automatically does the same as this:
+    # b64_id_secret = b64encode(bytes(client_id + ":" + client_secret, "utf-8")).decode("utf-8")
+    # no need to include explicit Basic Authorization headers in request:
+    # headers={"Authorization": "Basic " + b64_id_secret},
+
+    response = requests.post(
+        xero_config["token_url"],
+        auth=(xero_config["client_id"], xero_config["client_secret"]),
+        data={
+            "grant_type": "authorization_code",
+            "code": auth_code,
+            "redirect_uri": xero_config["redirect_url"],
+        },
+    )
+    json_response = response.json()
+    _store_refresh_token(xero_config, json_response["refresh_token"])
+    return json_response["access_token"]
+
+
+def _get_token_from_refresh_token(refresh_token: str, xero_config: config_dict) -> str:
+    response = requests.post(
+        xero_config["token_url"],
+        auth=(xero_config["client_id"], xero_config["client_secret"]),
+        data={
+            "grant_type": "refresh_token",
+            "refresh_token": refresh_token,
+        },
+    )
+    json_response = response.json()
+    _store_refresh_token(xero_config, json_response["refresh_token"])
+    return json_response["access_token"]
+
+
+def get_access_token(xero_config: config_dict) -> str:
+    # If we have a refresh token stored, use it to get a new access token.
+    # Otherwise, we have to use the web-based authorization flow to get
+    # an access code and exchange it for an access token.
+    refresh_token = _get_refresh_token(xero_config)
+    if refresh_token:
+        # use it
+        access_token = _get_token_from_refresh_token(refresh_token, xero_config)
+    else:
+        # Use the web-based authorization flow
+        auth_request_url = _get_auth_request_url(xero_config)
+        webbrowser.open_new(auth_request_url)
+
+        auth_response_url = input("What URL did Xero return? ")
+        auth_code = _get_auth_code(auth_response_url)
+        access_token = _get_token_from_auth_code(auth_code, xero_config)
+
+    return access_token
+
+
+def get_tenant_id(access_token: str, xero_config: config_dict) -> str:
+    response = requests.get(
+        xero_config["tenant_url"],
+        headers={
+            "Authorization": "Bearer " + access_token,
+            "Content-Type": "application/json",
+        },
+    )
+    json_response = response.json()
+    # Response is a list of dicts, one for each organization associated with our credentials.
+    # We should have just one... probably could hard-code it, but for now, just return the
+    # first "ORGANISATION" tenant id found.
+    tenant_ids = [
+        tenant["tenantId"]
+        for tenant in json_response
+        if tenant["tenantType"] == "ORGANISATION"
+    ]
+    return tenant_ids[0]
+
+
+# def _api_usage_sucks_i_hate_this_sdk():
+#     api_client = ApiClient(
+#         Configuration(
+#             debug=False,
+#             oauth2_token=OAuth2Token(
+#                 client_id=xero_config["client_id"],
+#                 client_secret=xero_config["client_secret"],
+#             ),
+#         ),
+#         pool_threads=1,
+#     )
+
+#     @api_client.oauth2_token_getter
+#     def obtain_xero_oauth2_token():
+#         return xero_config["access_token"]
+
+#     @api_client.oauth2_token_saver
+#     def store_xero_oauth2_token(token):
+#         xero_config["access_token"] = access_token
+
+#     api_client.set_oauth2_token(access_token)
+
+#     accounting = AccountingApi(api_client)
+#     invoices = accounting.get_invoices
+#     pprint(invoices)
+
+
+def get_invoices(access_token: str, tenant_id: str):
+    get_url = "https://api.xero.com/api.xro/2.0/Invoices"
+    response = requests.get(
+        get_url,
+        headers={
+            "Authorization": "Bearer " + access_token,
+            "Xero-tenant-id": tenant_id,
+            "Accept": "application/json",
+        },
+    )
+    json_response = response.json()
+    # pprint(json_response, width=132)
+    invoices = json_response["Invoices"]
+    for invoice in invoices:
+        print(invoice["InvoiceNumber"], invoice["Status"], invoice["Total"])
+
+
+def main() -> None:
+    args = _get_args()
+    xero_config = _get_xero_config(args.config_file)
+    access_token = get_access_token(xero_config)
+    # # To make api_client happy, store access_token in config
+    # xero_config["access_token"] = access_token
+    tenant_id = get_tenant_id(access_token, xero_config)
+
+    get_invoices(access_token, tenant_id)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Implements [SYS-1820](https://uclalibrary.atlassian.net/browse/SYS-1820), sufficiently to confirm the Xero API can be used to obtain the item codes needed for UCLA when a user interacts with LPO to pay their invoices.

This is not nearly production-level code, just a proof of concept.  There's a Docker-based development environment for Python 3.13.  I tried using the [official Xero Python SDK](https://github.com/XeroAPI/xero-python) but found it to be really unwieldy; maybe the [Java SDK](https://github.com/XeroAPI/Xero-Java) is better.

I wound up adapting code from a [Jupyter notebllk](https://github.com/edgecate/Xero-APIs/blob/main/Xero%20API%20Tutorial.ipynb), mixed with a few direct calls to the [REST API](https://developer.xero.com/documentation/api/accounting/overview).


[SYS-1820]: https://uclalibrary.atlassian.net/browse/SYS-1820?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ